### PR TITLE
chore: update dependencies for dependabot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,11 +41,11 @@ dependencies {
     bundledLibs 'org.slf4j:slf4j-api'
     bundledLibs 'org.apache.httpcomponents:httpclient:4.5.13'
     bundledLibs 'com.google.code.gson:gson:2.8.6'
-    bundledLibs 'com.rabbitmq:amqp-client:5.9.0'
+    bundledLibs 'com.rabbitmq:amqp-client:5.12.0'
 
-    testImplementation 'org.codehaus.groovy:groovy:2.5.14'
-    testImplementation 'org.codehaus.groovy:groovy-dateutil:2.5.14'
-    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+    testImplementation 'org.codehaus.groovy:groovy:3.0.8'
+    testImplementation 'org.codehaus.groovy:groovy-dateutil:3.0.8'
+    testImplementation 'org.spockframework:spock-core:2.0-M5-groovy-3.0'
 }
 
 // Maven Central (technically sonatype oss) requires we distribute source and javadoc


### PR DESCRIPTION
- update to spock-core 2.0-M5 for groovy 3.0
- update to groovy 3.0.8
- update to groovy-dateutil 3.0.8
- update to amqp-client 5.12.0

Signed-off-by: Chris Replogle <Chris.Replogle@sas.com>