### PR TITLE
Match Event changes in Catalog

### DIFF
--- a/src/main/java/org/odpi/openmetadata/connector/sas/event/model/catalog/CatalogEventPayload.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/event/model/catalog/CatalogEventPayload.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.odpi.openmetadata.connector.sas.event.model.TypedPayload;
 import org.odpi.openmetadata.connector.sas.event.model.catalog.definition.Definition;
 import org.odpi.openmetadata.connector.sas.event.model.catalog.instance.Instance;
-//import com.sas.event.model.TypedPayload;
 
 public class CatalogEventPayload implements TypedPayload {
     public static final String PAYLOAD_TYPE = "application/vnd.sas.catalog.event";
@@ -17,6 +16,7 @@ public class CatalogEventPayload implements TypedPayload {
     private String action;
     private String actionState;
     private String objectType;
+    private String operation;
     private Instance instance;
     private Definition definition;
 
@@ -78,4 +78,13 @@ public class CatalogEventPayload implements TypedPayload {
     public void setDefinition(Definition definition) {
         this.definition = definition;
     }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
+
 }

--- a/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/RepositoryConnector.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/RepositoryConnector.java
@@ -75,8 +75,8 @@ public class RepositoryConnector extends OMRSRepositoryConnector
                 raiseConnectorCheckedException(ErrorCode.REST_CLIENT_FAILURE, methodName, null, "null");
             } else {
                 this.url = endpointProperties.getProtocol() + "://" + endpointProperties.getAddress();
-                this.sasCatalogClient = new SASCatalogRestClient(this.url, this.connectionProperties.getUserId(),
-                        this.connectionProperties.getClearPassword());
+                this.sasCatalogClient = new SASCatalogRestClient(this.url, this.securedProperties.get("userId"),
+                        this.securedProperties.get("password"));
             }
         }
         metadataCollection = new MetadataCollection(this,


### PR DESCRIPTION
Catalog underwent changes to its event structure that the Egeria connector has to match.

Also moves credentials in the configuration step to the "securedProperties" field, which shouldn't come back when querying for the configuration (this is not the case currently, however, due to [this bug](https://github.com/odpi/egeria/issues/5485).