### PR TITLE
odpi/egeria#5686 fully qualify base image name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # These may be supplied by the pipeline in future - until then they will default
 
 ARG version=latest
-ARG EGERIA_BASE_IMAGE=odpi/egeria
+ARG EGERIA_BASE_IMAGE=docker.io/odpi/egeria
 # DEFER setting this for now, using the ${version}:
 # ARG EGERIA_IMAGE_DEFAULT_TAG=latest
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fully qualify docker base image names as per https://github.com/odpi/egeria/issues/5670

Note: I've not touched the deployment scripts as I have no way of testing and knowing how you have your repos setup, but you may wish to add the same qualification there
    
    