### PR TITLE
odpi/egeria#5702 Update gradle to 7.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Updates gradle wrapper to 7.3
* Fixes Java compatability issue with Java 17 (egeria targets latest LTS:11 + current:17 (best efforts))
* Further info at Update 'latest' (verification only) build scripts to Java 17/Gradle 7.3 egeria#5702
* CI/CD does not build Java 17