### PR TITLE
Update mappings for SchemaAttributeType relationships

### DIFF
--- a/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/MetadataCollection.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/MetadataCollection.java
@@ -320,22 +320,10 @@ public class MetadataCollection extends OMRSMetadataCollectionBase {
         String prefix = sasCatalogGuid.getGeneratedPrefix();
         SASCatalogObject entity = getSASCatalogEntitySafe(sasCatalogGuid.getSASCatalogGuid(), methodName);
 
-        String defName = entity.getTypeName();
-        Map<String, String> mappedOMRSTypeDefs = typeDefStore.getMappedOMRSTypeDefNameWithPrefixes(defName);
-        for (Map.Entry<String, String> entry : mappedOMRSTypeDefs.entrySet())
-        {
-            prefix = entry.getKey();
-            // TODO: Do we need an attributeTypeDefStore like Atlas?
-            EntityMappingSASCatalog2OMRS mapping = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null /*attributeTypeDefStore */, entity, prefix, userId);
-            EntityDetail entityDetail = mapping.getEntityDetail();
-            if (entityDetail != null) {
-                return entityDetail;
-            }
-        }
         // TODO: Do we need an attributeTypeDefStore like Atlas?
-        //EntityMappingSASCatalog2OMRS mapping = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null /*attributeTypeDefStore */, entity, prefix, userId);
-        //return mapping.getEntityDetail();
-        return null;
+        EntityMappingSASCatalog2OMRS mapping = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null /*attributeTypeDefStore */, entity, prefix, userId);
+        return mapping.getEntityDetail();
+        //return null;
     }
 
     @Override

--- a/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRS.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRS.java
@@ -316,6 +316,50 @@ public class EntityMappingSASCatalog2OMRS {
             }
         }
 
+        // Then handle any generated relationships (between what is the same entity in
+        // SAS but different entities in OMRS)
+        if (relationshipTypeGUID == null) {
+            Map<String, TypeDefStore.EndpointMapping> mappedRelationships = typeDefStore
+                    .getAllEndpointMappingsFromCatalogName(sasEntity.getTypeName());
+            for (Map.Entry<String, TypeDefStore.EndpointMapping> entry : mappedRelationships.entrySet()) {
+                String relationshipPrefix = entry.getKey();
+                // TypeDefStore.EndpointMapping mapping = entry.getValue();
+                // Only generate the generated relationships (normally-mapped should be covered
+                // already above)
+                if (relationshipPrefix != null) {
+                    // TODO: assumes that all generated relationships have the same Atlas entity on
+                    // both ends
+                    SASCatalogGuid sasGuid = new SASCatalogGuid(sasEntity.getGuid(), relationshipPrefix);
+                    Relationship omrsRelationship = RelationshipMapping.getSelfReferencingRelationship(
+                            sasRepositoryConnector,
+                            typeDefStore,
+                            sasGuid,
+                            sasEntity);
+                    if (omrsRelationship != null) {
+                        omrsRelationships.add(omrsRelationship);
+                    } else {
+                        raiseRepositoryErrorException(ErrorCode.RELATIONSHIP_NOT_KNOWN, methodName, null,
+                                sasGuid.toString(), methodName, repositoryName);
+                    }
+                }
+            }
+        } else {
+            TypeDef typeDef = typeDefStore.getTypeDefByGUID(relationshipTypeGUID);
+            if (typeDef != null) {
+                String omrsTypeDefName = typeDef.getName();
+                Map<String, String> sasTypesByPrefix = typeDefStore.getAllMappedCatalogTypeDefNames(omrsTypeDefName);
+                for (Map.Entry<String, String> entry : sasTypesByPrefix.entrySet()) {
+                    String prefixForType = entry.getKey();
+                    String sasTypeNames = entry.getValue();
+                    // TODO: Only generate the generated relationships (normally-mapped should be
+                    // covered already above)
+                    if (prefixForType != null) {
+                        log.info("Have not yet implemented this relationship: ({}) {}", prefixForType, sasTypeNames);
+                    }
+                }
+            }
+        }
+
         if (omrsRelationships != null) {
             // Now sort the results, if requested
             Comparator<Relationship> comparator = SequencingUtils.getRelationshipComparator(sequencingOrder,

--- a/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRS.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRS.java
@@ -327,8 +327,8 @@ public class EntityMappingSASCatalog2OMRS {
                 // Only generate the generated relationships (normally-mapped should be covered
                 // already above)
                 if (relationshipPrefix != null) {
-                    // TODO: assumes that all generated relationships have the same Atlas entity on
-                    // both ends
+                    // TODO: assumes that all generated relationships have the same Catalog entity on
+                    // both ends ie relationshipTable <--> relationshipTableType
                     SASCatalogGuid sasGuid = new SASCatalogGuid(sasEntity.getGuid(), relationshipPrefix);
                     Relationship omrsRelationship = RelationshipMapping.getSelfReferencingRelationship(
                             sasRepositoryConnector,

--- a/src/main/resources/TypeDefMappings.json
+++ b/src/main/resources/TypeDefMappings.json
@@ -170,7 +170,6 @@
   {
     "sasCat": "casTable",
     "omrs": "RelationalTable",
-    "prefix": "CASTRT",
     "propertyMappings": [
       {
         "sasCat": "instance.name",
@@ -213,10 +212,23 @@
       }
     ]
   },
+    {
+    "sasCat": "casTable",
+    "omrs": "SchemaAttributeType",
+    "prefix": "HTSAT",
+    "endpointMappings": [
+      {
+        "omrs": "usedInSchemas"
+      },
+      {
+        "omrs": "type",
+        "prefix": "CASTRTT"
+      }
+    ]
+  },
   {
     "sasCat": "sasTable",
     "omrs": "RelationalTable",
-    "prefix": "SASTRT",
     "propertyMappings": [
       {
         "sasCat": "instance.name",
@@ -256,6 +268,20 @@
       {
         "sasCat": "instance.createdBy",
         "omrs": "author"
+      }
+    ]
+  },
+  {
+    "sasCat": "sasTable",
+    "omrs": "SchemaAttributeType",
+    "prefix": "HTSAT",
+    "endpointMappings": [
+      {
+        "omrs": "usedInSchemas"
+      },
+      {
+        "omrs": "type",
+        "prefix": "SASTRTT"
       }
     ]
   },
@@ -346,15 +372,48 @@
     ]
   },
   {
-    "sasCat": "dataSetDataFields",
+    "sasCat": "reference.casTable",
+    "omrs": "RelationalTableType",
+    "prefix": "RCTRTT",
+    "propertyMappings": [
+      {
+        "sasCat": "instance.name",
+        "omrs": "qualifiedName"
+      },
+      {
+        "sasCat": "instance.label",
+        "omrs": "displayName"
+      },
+      {
+        "sasCat": "instance.createdBy",
+        "omrs": "author"
+      }
+    ]
+  },
+  {
+    "sasCat": "reference.casTable",
     "omrs": "SchemaAttributeType",
-    "prefix": "DSTDFSAT",
+    "prefix": "RCTSAT",
     "endpointMappings": [
       {
         "omrs": "usedInSchemas"
       },
       {
-        "omrs": "type"
+        "omrs": "type",
+        "prefix": "RCTRTT"
+      }
+    ]
+  },
+  {
+    "sasCat": "dataSetDataFields",
+    "omrs": "NestedSchemaAttribute",
+    "prefix": "SASDSTDF",
+    "endpointMappings": [
+      {
+        "omrs": "parentSchemas"
+      },
+      {
+        "omrs": "attributes"
       }
     ]
   },
@@ -374,7 +433,6 @@
   {
     "sasCat": "casColumn",
     "omrs": "RelationalColumn",
-    "prefix": "CASCRC",
     "propertyMappings": [
       {
         "sasCat": "instance.name",
@@ -462,9 +520,22 @@
     ]
   },
   {
+    "sasCat": "casColumn",
+    "omrs": "SchemaAttributeType",
+    "prefix": "CCSAT",
+    "endpointMappings": [
+      {
+        "omrs": "usedInSchemas"
+      },
+      {
+        "omrs": "type",
+        "prefix": "CASCRCT"
+      }
+    ]
+  },
+  {
     "sasCat": "sasColumn",
     "omrs": "RelationalColumn",
-    "prefix": "SASCRC",
     "propertyMappings": [
       {
         "sasCat": "instance.name",
@@ -528,9 +599,22 @@
   ]
   },
   {
+    "sasCat": "sasColumn",
+    "omrs": "SchemaAttributeType",
+    "prefix": "SCSAT",
+    "endpointMappings": [
+      {
+        "omrs": "usedInSchemas"
+      },
+      {
+        "omrs": "type",
+        "prefix": "SASCRCT"
+      }
+    ]
+  },
+  {
   "sasCat": "casLibrary",
   "omrs": "DataStore",
-  "prefix": "CASLDS",
   "propertyMappings": [
     {
       "sasCat": "instance.name",
@@ -561,7 +645,6 @@
   {
   "sasCat": "sasLibrary",
   "omrs": "DataStore",
-  "prefix": "SASLDS",
   "propertyMappings": [
     {
       "sasCat": "instance.name",
@@ -592,7 +675,6 @@
   {
     "sasCat": "managedModel",
     "omrs": "DesignModel",
-    "prefix": "MMDM",
     "propertyMappings": [
       {
         "sasCat": "instance.name",
@@ -619,7 +701,6 @@
   {
     "sasCat": "analyticStore",
     "omrs": "ConceptModelElement",
-    "prefix": "ASCME",
     "propertyMappings": [
       {
         "sasCat": "instance.name",

--- a/src/test/groovy/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRSTest.groovy
+++ b/src/test/groovy/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRSTest.groovy
@@ -182,7 +182,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with CASTRT prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "CASTRT", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == relTableTypeDef.getName()
@@ -274,7 +274,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with SASTRT prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "SASTRT", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == relTableTypeDef.getName()
@@ -334,7 +334,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with CASCRC prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "CASCRC", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == relColumnTypeDef.getName()
@@ -402,7 +402,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with SASCRC prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "SASCRC", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == relColumnTypeDef.getName()
@@ -460,7 +460,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with CASLDS prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "CASLDS", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == dataStoreTypeDef.getName()
@@ -499,7 +499,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with SASLDS prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "SASLDS", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == dataStoreTypeDef.getName()
@@ -538,7 +538,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with MMDM prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "MMDM", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == designModelTypeDef.getName()
@@ -577,7 +577,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityDetail detail
 
         when: "I get entity detail with ASCME prefix"
-        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, "ASCME", "steven")
+        mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
         detail.getType().getTypeDefName() == conceptModelElemTypeDef.getName()

--- a/src/test/groovy/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRSTest.groovy
+++ b/src/test/groovy/org/odpi/openmetadata/connector/sas/repository/connector/mapping/EntityMappingSASCatalog2OMRSTest.groovy
@@ -181,7 +181,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with CASTRT prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -273,7 +273,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with SASTRT prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -333,7 +333,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with CASCRC prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -401,7 +401,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with SASCRC prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -459,7 +459,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with CASLDS prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -498,7 +498,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with SASLDS prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -537,7 +537,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with MMDM prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"
@@ -576,7 +576,7 @@ class EntityMappingSASCatalog2OMRSTest extends Specification {
         EntityMappingSASCatalog2OMRS mapper
         EntityDetail detail
 
-        when: "I get entity detail with ASCME prefix"
+        when: "I get entity detail with no prefix"
         mapper = new EntityMappingSASCatalog2OMRS(repositoryConnector, typeDefStore, null, instance, null, "steven")
         detail = mapper.getEntityDetail()
         then: "Values should be mapped correctly"


### PR DESCRIPTION

Return generated relationships in getRelationships

Use NestedSchemaAttribute for columns.

Remove prefix for default mapping. Prefixes remain for generated
entities and relationships.

Update tests for prefix changes.