### PR TITLE
Enhanced K8s Configuration Script and Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,8 @@ LABEL org.opencontainers.image.description = "Egeria with SAS Viya connector" \
 WORKDIR .
 COPY build/libs/egeria-connector-viya-4-${version}*.jar /deployments/server/lib
 
-# Mount security/trustedcerts.jks at runtime
-ENV JAVA_OPTS_APPEND -XX:MaxMetaspaceSize=1g -Djavax.net.ssl.trustStore=/security/trustedcerts.jks -Dsas.egeria.repositoryconnector.ssl.trustAll=false
+# Mount security/trustedcerts.jks at runtime and set connector to automatically restart
+ENV JAVA_OPTS_APPEND -XX:MaxMetaspaceSize=1g -Djavax.net.ssl.trustStore=/security/trustedcerts.jks -Dsas.egeria.repositoryconnector.ssl.trustAll=false -Dstartup.server.list=\${EGERIA_SERVER_NAME}
+
+# Uncomment to enable Java remote debugging
+# ENV JAVA_DEBUG 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR .
 COPY build/libs/egeria-connector-viya-4-${version}*.jar /deployments/server/lib
 
 # Mount security/trustedcerts.jks at runtime and set connector to automatically restart
-ENV JAVA_OPTS_APPEND -XX:MaxMetaspaceSize=1g -Djavax.net.ssl.trustStore=/security/trustedcerts.jks -Dsas.egeria.repositoryconnector.ssl.trustAll=false -Dstartup.server.list=\${EGERIA_SERVER_NAME}
+ENV JAVA_OPTS_APPEND -XX:MaxMetaspaceSize=1g -Djavax.net.ssl.trustStore=/security/trustedcerts.jks -Dlogging.level.root=INFO -Dsas.egeria.repositoryconnector.ssl.trustAll=false -Dstartup.server.list=\${EGERIA_SERVER_NAME}
 
 # Uncomment to enable Java remote debugging
 # ENV JAVA_DEBUG 1

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     bundledLibs 'com.google.code.gson:gson:2.8.9'
     bundledLibs 'com.rabbitmq:amqp-client:5.14.0'
 
+
     testImplementation 'org.codehaus.groovy:groovy:3.0.9'
     testImplementation 'org.codehaus.groovy:groovy-dateutil:3.0.9'
     testImplementation 'org.spockframework:spock-core:2.1-groovy-3.0-SNAPSHOT'

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -1,8 +1,10 @@
 # Deploy to a Viya Kubernetes Cluster
-1. Create a new directory named `egeria-connector` in `<your kubernetes deployment root directory>/sas-bases/overlays` and then copy the following files to this new directory:
-    * deployment.yaml
-    * kustomization.yaml
-    * tls-transformer.yaml
+1. Create a new directory named `egeria-connector` in `<your kubernetes deployment root directory>/sas-bases/overlays` and then copy the following YAML files to the new directory.
+   * deployment.yaml
+   * kustomization.yaml
+   * mount-pvc.yaml
+   * pvc.yaml
+   * tls-transformer.yaml
 
 2. If your Viya deployment uses full-stack (default) or frontdoor TLS modes, you can skip this step.
 If your deployment uses the truststores-only mode, comment out the following lines in kustomization.yaml:
@@ -10,14 +12,27 @@ If your deployment uses the truststores-only mode, comment out the following lin
 # transformers:
 # - tls-transformer.yaml
 ```
+   
+3. Create a new file in the `egeria-connector` directory named `kustomization.yaml` with the contents:
+```yaml
+resources:
+  - deployment.yaml
+```
 
-3. Navigate back to the Kubernetes install root directory, and add the following line to `kustomization.yaml` under the `resources` section
+4. Navigate back to the Kubernetes install root directory, and add the following line to `kustomization.yaml` under the `resources` section
 ```yaml
   - sas-bases/overlays/egeria-connector
 ```
 
-4. From the install directory, run the command `kustomize build > /tmp/deployment`
+5. From the install directory, run the command `kustomize build > /tmp/deployment`
 
-5. Ensure your KUBECONFIG is set correctly with admin privileges and then apply the new changes with `kubectl apply -f /tmp/deployment`
+6. Ensure your KUBECONFIG is set correctly with admin privileges and then apply the new changes with `kubectl apply -f /tmp/deployment`
 
-6. Set the appropriate variables in `configure.sh` from this repository and run it to configure the connector to connect to your Catalog service
+7. Run `configure.sh` to configure the connector to connect to your Catalog service.  The script may be run in interactive mode to prompt for the necessary values or the values may be specified on the command line.  NOTE: The configure.sh script need only be run once.  The connector will persist the configureation values and reuse them upon startup.
+    * `configure.sh -i`
+    * `configure.sh <SAS Viya cluster root url> <Egeria admin username> <Catalog username> <Catalog password>`
+    * For example: `configure.sh https://myviyacluster.companyname.com garygeeke sasuser saspassword`
+
+8. For reference, the repository connector starts a local Egeria server named, `SASRepositoryProxy`
+
+

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -28,11 +28,15 @@ resources:
 
 6. Ensure your KUBECONFIG is set correctly with admin privileges and then apply the new changes with `kubectl apply -f /tmp/deployment`
 
-7. Run `configure.sh` to configure the connector to connect to your Catalog service.  The script may be run in interactive mode to prompt for the necessary values or the values may be specified on the command line.  NOTE: The configure.sh script need only be run once.  The connector will persist the configureation values and reuse them upon startup.
+7. Run `configure.sh` to configure the connector to connect to your Catalog service.  The script may be run in interactive mode to prompt for the necessary values or the values may be specified on the command line.  
+   1. If you wish to have the SAS connector join a remote Egeria cohort then specify the optional values for the remote Egeria server's Kafka hostname, Kafka port and cohort name.
+   2. NOTE: The configure.sh script need only be run once.  The connector will persist the configuration values and reuse them upon startup.
+   3. Usage:
     * `configure.sh -i`
     * `configure.sh <SAS Viya cluster root url> <Egeria admin username> <Catalog username> <Catalog password>`
+      `             [<Kafka hostname> <Kafka port> <cohort name>`
     * For example: `configure.sh https://myviyacluster.companyname.com garygeeke sasuser saspassword`
 
-8. For reference, the repository connector starts a local Egeria server named, `SASRepositoryProxy`
+9. For reference, the repository connector starts a local Egeria server named, `SASRepositoryProxy`
 
 

--- a/deployment/kubernetes/configure.sh
+++ b/deployment/kubernetes/configure.sh
@@ -3,21 +3,37 @@
 if [ "$#" -lt 1 ]; then
     echo "Usage: configure.sh -i"
     echo "       configure.sh <SAS Viya cluster root url> <Egeria admin username> <Catalog username> <Catalog password>"
+    echo "                    [<Kafka hostname> <Kafka port> <cohort name>]"
     exit 1
 fi
+
+export KAFKA_HOST
 
 if [ "$1" = "-i" ]; then
     echo "Enter SAS Viya cluster root url (e.g. https://myhost.com): "
     read CLUSTER_ROOT_URL
-    echo "Enter Egeria admin username"
+    echo ""
+    echo "Enter Egeria admin username:"
     read EGERIA_USER
-    echo "Enter Catalog service username"
+    echo ""
+    echo "Enter Catalog service username:"
     read CATALOG_USER
-    echo "Enter Catalog service username's password"
+    echo ""
+    echo "Enter Catalog service password:"
     read CATALOG_PASS
+    echo ""
+    echo "Enter Kafka hostname [kafkahost]:"
+    read KAFKA_HOST
+    echo ""
+    echo "Enter Kafka port [9092]:"
+    read KAFKA_PORT
+    echo ""
+    echo "Enter cohort name []:"
+    read COHORT_NAME
 elif [ "$#" -lt 4 ]; then
     echo "Usage: configure.sh -i"
     echo "       configure.sh <SAS Viya cluster root url> <Egeria admin username> <Catalog username> <Catalog password>"
+    echo "                    [<Kafka hostname> <Kafka port> <cohort name>]"
     exit 1
 else
     # set variables from command line
@@ -25,6 +41,19 @@ else
     EGERIA_USER=$2
     CATALOG_USER=$3
     CATALOG_PASS=$4
+    KAFKA_HOST=$5
+    KAFKA_PORT=$6
+    COHORT_NAME=$7
+fi
+
+# default KAFKA_HOST if necessary
+if [ "${KAFKA_HOST}" = "" ]; then
+    KAFKA_HOST="kafkahost"
+fi
+
+# default KAFKA_PORT if necessary
+if [ "${KAFKA_PORT}" = "" ]; then
+    KAFKA_PORT="9092"
 fi
 
 # extract the protocol
@@ -47,9 +76,9 @@ EGERIA_SERVER="SASRepositoryProxy"
 
 set -e
 
-echo "Configure Catalog connection"
 
 # Configure Catalog connection
+echo "Configuring Catalog connection for ${CLUSTER_SCHEME}://${CLUSTER_HOST} ..."
 curl --location --request POST -k "${CLUSTER_SCHEME}://${CLUSTER_HOST}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/local-repository/mode/repository-proxy/connection" \
 --header 'Content-Type: application/json' \
 --data-raw "{
@@ -69,28 +98,37 @@ curl --location --request POST -k "${CLUSTER_SCHEME}://${CLUSTER_HOST}/open-meta
   }
 }"
 
-echo "Configure cohort event bus"
 # Configure cohort event bus
+echo "Configuring cohort event bus to ${KAFKA_HOST}:${KAFKA_PORT} ..."
 curl --location --request POST -k "${CLUSTER_SCHEME}://${CLUSTER_HOST}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/event-bus?connectorProvider=org.odpi.openmetadata.adapters.eventbus.topic.kafka.KafkaOpenMetadataTopicProvider&topicURLRoot=OMRSTopic" \
 --header "Content-Type: application/json" \
 --data-raw "{
   \"producer\": {
-    \"bootstrap.servers\":\"kafkahost:9092\"
+    \"bootstrap.servers\":\"${KAFKA_HOST}:${KAFKA_PORT}\"
   },
   \"consumer\": {
-    \"bootstrap.servers\":\"kafkahost:9092\"
+    \"bootstrap.servers\":\"${KAFKA_HOST}:${KAFKA_PORT}\"
   }
 }"
 
-echo "Configure event connector (Viya RabbitMQ)"
 # Configure event connector (Viya RabbitMQ)
+echo "Configuring event connector (Viya RabbitMQ) ..."
 curl --location --request POST -k "${CLUSTER_SCHEME}://${CLUSTER_HOST}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/local-repository/event-mapper-details?connectorProvider=org.odpi.openmetadata.connector.sas.event.mapper.RepositoryEventMapperProvider&eventSource=" \
 --header "Content-Type: application/json" \
 --data-raw "{}"
 
-echo "Start Egeria Server"
+# Join Cohort
+if [ "${COHORT_NAME}" != "" ]; then
+    echo "Joining Cohort: ${COHORT_NAME} ..."
+    curl --location --request POST -k "${CLUSTER_SCHEME}://${CLUSTER_HOST}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/cohorts/${COHORT_NAME}"
+fi
+
+
 # Start Egeria Server
+echo "Starting Egeria Server ..."
 curl --location --request POST -k "${CLUSTER_SCHEME}://${CLUSTER_HOST}/open-metadata/admin-services/users/${EGERIA_USER}/servers/${EGERIA_SERVER}/instance" \
 --header "Content-Type: application/json"
 
+
+echo "Done."
 exit 0

--- a/deployment/kubernetes/deployment.yaml
+++ b/deployment/kubernetes/deployment.yaml
@@ -59,6 +59,8 @@ spec:
                 secretKeyRef:
                   name: sas-rabbitmq-server-secret
                   key: RABBITMQ_DEFAULT_PASS
+            - name: EGERIA_SERVER_NAME
+              value: SASRepositoryProxy
           ports:
             - name: egeria-port
               containerPort: 9443

--- a/deployment/kubernetes/kustomization.yaml
+++ b/deployment/kubernetes/kustomization.yaml
@@ -3,8 +3,14 @@ kind: Kustomization
 
 resources:
 - deployment.yaml
+- pvc.yaml
 
 # The following is required if your Viya deployment uses the full-stack or frontdoor TLS modes.
 # If your Viya deployment uses the truststores-only mode, please comment out the following two lines.
 transformers:
 - tls-transformer.yaml
+
+patches:
+  - target:
+      kind: StatefulSet
+    path: mount-pvc.yaml

--- a/deployment/kubernetes/mount-pvc.yaml
+++ b/deployment/kubernetes/mount-pvc.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: sas-egeriaconfig-volume
+    persistentVolumeClaim:
+      claimName: sas-egeriaconfig
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: sas-egeriaconfig-volume
+    mountPath: /deployments/data

--- a/deployment/kubernetes/pvc.yaml
+++ b/deployment/kubernetes/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sas-egeriaconfig
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+     requests:
+       storage: 50Mi

--- a/src/main/java/org/odpi/openmetadata/connector/sas/client/SASCatalogRestClient.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/client/SASCatalogRestClient.java
@@ -79,9 +79,9 @@ public class SASCatalogRestClient implements SASCatalogClient {
         this.baseURL = baseURL;
         this.username = username;
         this.password = password;
-        URIBuilder builder = new URIBuilder(baseURL);
+        URIBuilder builder = new URIBuilder(this.baseURL);
         this.scheme = builder.getScheme();
-        log.info("Creating catalog client with base URL: " + baseURL + " and username: " + username);
+        log.info("Creating catalog client with base URL: " + this.baseURL + " and username: " + username);
         // Get initial token
         setAuthToken(username, password);
     }

--- a/src/main/java/org/odpi/openmetadata/connector/sas/client/SASCatalogRestClient.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/client/SASCatalogRestClient.java
@@ -84,7 +84,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
     }
 
     private void setAuthToken(String username, String password) throws Exception {
-        URIBuilder builder = new URIBuilder(this.baseURL + "/SASLogon/oauth/token");
+        URIBuilder builder = new URIBuilder("https://sas-logon-app/SASLogon/oauth/token");
         builder.addParameter("grant_type", "password");
         builder.addParameter("username", username);
         builder.addParameter("password", password);

--- a/src/main/java/org/odpi/openmetadata/connector/sas/client/SASCatalogRestClient.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/client/SASCatalogRestClient.java
@@ -41,6 +41,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
     private String baseURL;
     private String username;
     private String password;
+    private String scheme;
     private String token;
 
     private static final Logger log = LoggerFactory.getLogger(SASCatalogRestClient.class);
@@ -78,13 +79,15 @@ public class SASCatalogRestClient implements SASCatalogClient {
         this.baseURL = baseURL;
         this.username = username;
         this.password = password;
+        URIBuilder builder = new URIBuilder(baseURL);
+        this.scheme = builder.getScheme();
         log.info("Creating catalog client with base URL: " + baseURL + " and username: " + username);
         // Get initial token
         setAuthToken(username, password);
     }
 
     private void setAuthToken(String username, String password) throws Exception {
-        URIBuilder builder = new URIBuilder("https://sas-logon-app/SASLogon/oauth/token");
+        URIBuilder builder = new URIBuilder(this.scheme + "://sas-logon-app/SASLogon/oauth/token");
         builder.addParameter("grant_type", "password");
         builder.addParameter("username", username);
         builder.addParameter("password", password);
@@ -117,7 +120,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
 
         SASCatalogObject instanceInfo = new SASCatalogObject();
 
-        URIBuilder builder = new URIBuilder(this.baseURL + "/catalog/instances/" + guid);
+        URIBuilder builder = new URIBuilder(this.scheme + "://sas-catalog/catalog/instances/" + guid);
         HttpGet httpGet = new HttpGet(builder.build());
         addAuthHeader(httpGet);
         httpGet.addHeader("Accept", String.format("application/vnd.sas.metadata.instance.%s+json", type));
@@ -160,7 +163,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
 
         List<Instance> instances = new ArrayList<>();
 
-        URIBuilder builder = new URIBuilder(this.baseURL + "/catalog/instances");
+        URIBuilder builder = new URIBuilder(this.scheme + "://sas-catalog/catalog/instances");
         for(Map.Entry<String, String> param : params.entrySet()) {
             log.info("Param: " + param.getKey() + " : " + param.getValue());
             builder.addParameter(param.getKey(), param.getValue());
@@ -214,7 +217,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
             throw new RuntimeException("Could not complete request after " + retries + " retries.");
         }
 
-        URIBuilder builder = new URIBuilder(this.baseURL + "/catalog/definitions/" + definitionId);
+        URIBuilder builder = new URIBuilder(this.scheme + "://sas-catalog/catalog/definitions/" + definitionId);
         HttpGet httpGet = new HttpGet(builder.build());
         httpGet.addHeader("Accept", String.format("application/vnd.sas.metadata.definition.%s+json", type));
         addAuthHeader(httpGet);
@@ -267,7 +270,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
             defName = "reference";
         }
 
-        URIBuilder builder = new URIBuilder(this.baseURL + "/catalog/definitions");
+        URIBuilder builder = new URIBuilder(this.scheme + "://sas-catalog/catalog/definitions");
         builder.addParameter("filter", String.format("and(eq(name,%s),eq(definitionType,%s))", defName, type));
         HttpGet httpGet = new HttpGet(builder.build());
         addAuthHeader(httpGet);
@@ -299,7 +302,7 @@ public class SASCatalogRestClient implements SASCatalogClient {
 
         List<SASCatalogObject> relationships = new ArrayList<>();
 
-        URIBuilder builder = new URIBuilder(this.baseURL + "/catalog/instances");
+        URIBuilder builder = new URIBuilder(this.scheme + "://sas-catalog/catalog/instances");
         String filter = String.format("or(eq(endpoint1Id,'%s'),eq(endpoint2Id,'%s'))", guid, guid);
         builder.addParameter("filter", filter);
         HttpGet httpGet = new HttpGet(builder.build());

--- a/src/main/java/org/odpi/openmetadata/connector/sas/event/mapper/RepositoryEventMapper.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/event/mapper/RepositoryEventMapper.java
@@ -114,36 +114,41 @@ public class RepositoryEventMapper extends OMRSRepositoryEventMapperBase
                             host = address;
                         }
                     }
-                    if (StringUtils.isNotEmpty(host)) {
-                        // RabbitMQ host was configured, so set it in ConnectionFactory
-                        log.debug("Setting RabbitMQ host to: " + host);
-                        connectionFactory.setHost(host);
+                    if (StringUtils.isEmpty(host)) {
+                        host = "sas-rabbitmq-server";
                     }
-                    if (StringUtils.isNotEmpty(portAsString)) {
-                        try {
-                            int port = Integer.valueOf(portAsString);
-                            // RabbitMQ port was configured, so set it in ConnectionFactory
-                            log.debug("Setting RabbitMQ port to: " + portAsString);
-                            connectionFactory.setPort(port);
-                        }
-                        catch (NumberFormatException nfe) {
-                            log.error("Could not convert '{}' to a port number.  Default port will be used.", portAsString);
-                        }
+                    // RabbitMQ host was configured, so set it in ConnectionFactory
+                    log.debug("Setting RabbitMQ host to: " + host);
+                    connectionFactory.setHost(host);
+
+                    if (StringUtils.isEmpty(portAsString)) {
+                        portAsString = "5672";
+                    }
+                    try {
+                        int port = Integer.valueOf(portAsString);
+                        // RabbitMQ port was configured, so set it in ConnectionFactory
+                        log.debug("Setting RabbitMQ port to: " + portAsString);
+                        connectionFactory.setPort(port);
+                    }
+                    catch (NumberFormatException nfe) {
+                        log.error("Could not convert '{}' to a port number.  Default port will be used.", portAsString);
                     }
 
+                    String username = System.getenv("RABBITMQ_USER");
+                    String password = System.getenv("RABBITMQ_PASS");
                     if (cfgProperties != null) {
-                        String username = (String)cfgProperties.getOrDefault("username", "");
-                        String password = (String)cfgProperties.getOrDefault("password", "");
-                        if (StringUtils.isNotEmpty(username)) {
-                            // RabbitMQ username was configured, so set it in ConnectionFactory
-                            log.debug("Setting RabbitMQ username");
-                            connectionFactory.setUsername(username);
-                        }
-                        if (StringUtils.isNotEmpty(password)) {
-                            // RabbitMQ password was configured, so set it in ConnectionFactory
-                            log.debug("Setting RabbitMQ password");
-                            connectionFactory.setPassword(password);
-                        }
+                        username = (String)cfgProperties.getOrDefault("username", username);
+                        password = (String)cfgProperties.getOrDefault("password", password);
+                    }
+                    if (StringUtils.isNotEmpty(username)) {
+                        // RabbitMQ username was configured, so set it in ConnectionFactory
+                        log.debug("Setting RabbitMQ username");
+                        connectionFactory.setUsername(username);
+                    }
+                    if (StringUtils.isNotEmpty(password)) {
+                        // RabbitMQ password was configured, so set it in ConnectionFactory
+                        log.debug("Setting RabbitMQ password");
+                        connectionFactory.setPassword(password);
                     }
                 }
             }

--- a/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/MetadataCollection.java
+++ b/src/main/java/org/odpi/openmetadata/connector/sas/repository/connector/MetadataCollection.java
@@ -225,6 +225,35 @@ public class MetadataCollection extends OMRSMetadataCollectionBase {
      * {@inheritDoc}
      */
     @Override
+    public  void addAttributeTypeDef(String             userId,
+                                     AttributeTypeDef   newAttributeTypeDef) throws InvalidParameterException,
+            RepositoryErrorException,
+            TypeDefNotSupportedException,
+            TypeDefKnownException,
+            TypeDefConflictException,
+            InvalidTypeDefException,
+            FunctionNotSupportedException,
+            UserNotAuthorizedException
+    {
+        final String  methodName           = "addAttributeTypeDef";
+        final String  typeDefParameterName = "newAttributeTypeDef";
+
+        /*
+         * Validate parameters
+         */
+        this.newAttributeTypeDefParameterValidation(userId, newAttributeTypeDef, typeDefParameterName, methodName);
+
+        /*
+         * Perform operation
+         */
+        //reportUnsupportedOptionalFunction(methodName);
+        // TODO: provide implementation
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean verifyTypeDef(String  userId,
                                  TypeDef typeDef) throws InvalidParameterException,
             RepositoryErrorException,


### PR DESCRIPTION
These changes seek to improve the experience deploying the SAS Egeria Repository Proxy Connector into a Kubernetes environment.

NOTE: These changes also REQUIRE the SAS Egeria Repository Connector BE INSTALLED WITHIN THE VIYA K8S DEPLOYMENT.  This is because the connector is now utilizing K8s service hostname to communicate to SAS Viya services.

- Updated K8s deployment YAML to include a PVC to persist the Egeria configuration document
- Set the SAS Repository Proxy to have itself automatically restarted using the persisted configuration document
- Updated Repository Proxy code to utilize kubernetes service hostnames as we are running  within the Viya deployment
- Updated configure.sh to allow overriding the Kafka connection information to permit connecting to remote Egeria event bus
- Updated configure.sh to allow specification of a cohort name to permit the connector to join a remote Egeria cohort