### PR TITLE
Add mappings for non-reference entities

### DIFF
--- a/src/main/resources/TypeDefMappings.json
+++ b/src/main/resources/TypeDefMappings.json
@@ -26,6 +26,32 @@
     ]
   },
   {
+    "sasCat": "decision",
+    "omrs": "Asset",
+    "propertyMappings": [
+      {
+        "sasCat": "instance.name",
+        "omrs": "qualifiedName"
+      },
+      {
+        "sasCat": "instance.resourceId",
+        "omrs": "description"
+      },
+      {
+        "sasCat": "attribute.creator",
+        "omrs": "owner"
+      },
+      {
+        "sasCat": "instance.name",
+        "omrs": "name"
+      },
+      {
+        "sasCat": "attribute.dateModified",
+        "omrs": "latestChange"
+      }
+    ]
+  },
+  {
     "sasCat": "reference.modelStudioProject",
     "omrs": "DesignModel",
     "propertyMappings": [
@@ -48,6 +74,36 @@
       {
         "sasCat": "attribute.dateModified",
         "omrs": "latestChange"
+      }
+    ]
+  },
+  {
+    "sasCat": "dataPlan",
+    "omrs": "Process",
+    "propertyMappings": [
+      {
+        "sasCat": "instance.name",
+        "omrs": "qualifiedName"
+      },
+      {
+        "sasCat": "instance.id",
+        "omrs": "id"
+      },
+      {
+        "sasCat": "attribute.creator",
+        "omrs": "author"
+      },
+      {
+        "sasCat": "attribute.dateCreated",
+        "omrs": "createdTime"
+      },
+      {
+        "sasCat": "attribute.dateModified",
+        "omrs": "lastModifiedTime"
+      },
+      {
+        "sasCat": "attribute.editor",
+        "omrs": "modifier"
       }
     ]
   },


### PR DESCRIPTION
Adds mappings for non-reference data plans and decisions. These are enabled by the "DATAPREP-23647_HomePage_MetricsIndex" feature flag.

Signed-off-by: Steven Green <steven.greens10@gmail.com>